### PR TITLE
update git protocol

### DIFF
--- a/kong-plugin-jwt2header-1.0-3.rockspec
+++ b/kong-plugin-jwt2header-1.0-3.rockspec
@@ -2,7 +2,7 @@ package = "kong-jwt2header"
 version = "1.0-3"
 
 source = {
-  url = "git://github.com/yesinteractive/kong-jwt2header.git"
+  url = "https://github.com/yesinteractive/kong-jwt2header.git"
 }
 
 description = {


### PR DESCRIPTION
git protocol doesn't work anymore. we should replace it with HTTPS.
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
