### PR TITLE
Update kong-plugin-jwt2header-1.0-3.rockspec

### DIFF
--- a/kong-plugin-jwt2header-1.0-3.rockspec
+++ b/kong-plugin-jwt2header-1.0-3.rockspec
@@ -2,7 +2,7 @@ package = "kong-jwt2header"
 version = "1.0-3"
 
 source = {
-  url = "https://github.com/yesinteractive/kong-jwt2header.git"
+  url = "git+https://github.com/yesinteractive/kong-jwt2header"
 }
 
 description = {


### PR DESCRIPTION
I think this is how the source url should be defined.

I was having an issue when following this https://tech.aufomm.com/use-custom-plugins-with-kong/.

The git command that `luarocks` was trying to execute on my container to was this

```
fs.execute("'git'", "clone", "--depth=1", "git://github.com/yesinteractive/kong-jwt2header.git", "kong-jwt2header")
```

This fails 
```
Test2 /Users/rkazak/ >docker exec -it --user root kong-demo luarocks install kong-jwt2header

Installing https://luarocks.org/kong-jwt2header-1.0-3.rockspec
Cloning into 'kong-jwt2header'...
fatal: unable to connect to github.com:
github.com[0: 192.30.255.112]: errno=Connection refused


Error: Failed cloning git repository.
```
due to this ( I believe ).

```
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
Also for some reason I had to have the filename match the package as defined in the file?  So I am not sure if you will need to do that too.  I was using 

```
bash-5.0# luarocks --version
/usr/local/bin/luarocks 3.7.0
LuaRocks main command-line interface
```

